### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "datamigration",
     "name_pretty": "Cloud Database Migration Service",
     "product_documentation": "https://cloud.google.com/database-migration/",
-    "client_documentation": "https://googleapis.dev/python/datamigration/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/datamigration/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.