### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "datamigration",
     "name_pretty": "Cloud Database Migration Service",
     "product_documentation": "https://cloud.google.com/database-migration/",
-    "client_documentation": "https://googleapis.dev/python/datamigration/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/datamigration/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Cloud Database Migration Service
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dms.svg
    :target: https://pypi.org/project/google-cloud-dms/
 .. _Cloud Database Migration Service: https://cloud.google.com/database-migration/
-.. _Client Library Documentation: https://googleapis.dev/python/datamigration/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/datamigration/latest
 .. _Product Documentation:  https://cloud.google.com/database-migration/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.